### PR TITLE
Refactor NetworkResult package and add new error string

### DIFF
--- a/core/common/src/main/java/com/ibrahimkurt/core/common/network/NetworkResult.kt
+++ b/core/common/src/main/java/com/ibrahimkurt/core/common/network/NetworkResult.kt
@@ -1,8 +1,8 @@
-package com.ibrahimkurt.core.network.calladapter
+package com.ibrahimkurt.core.common.network
 
 import androidx.annotation.StringRes
+import com.ibrahimkurt.core.common.R
 import com.ibrahimkurt.core.common.util.Constants.EMPTY_STRING
-import com.ibrahimkurt.core.network.R
 
 sealed interface NetworkResult<out T> {
     data class Success<T>(val data: T) : NetworkResult<T>

--- a/core/common/src/main/res/values/strings.xml.xml
+++ b/core/common/src/main/res/values/strings.xml.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="error_unknown">Bilinmeyen bir hata oluştu, bir süre sonra tekrar deneyiniz.</string>
+</resources>

--- a/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCall.kt
+++ b/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCall.kt
@@ -1,5 +1,6 @@
 package com.ibrahimkurt.core.network.calladapter
 
+import com.ibrahimkurt.core.common.network.NetworkResult
 import com.ibrahimkurt.core.network.util.ErrorCategory
 import com.ibrahimkurt.core.network.util.NetworkUnavailableException
 import okhttp3.Request

--- a/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCallAdapter.kt
+++ b/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCallAdapter.kt
@@ -1,5 +1,6 @@
 package com.ibrahimkurt.core.network.calladapter
 
+import com.ibrahimkurt.core.common.network.NetworkResult
 import retrofit2.Call
 import retrofit2.CallAdapter
 import java.lang.reflect.Type

--- a/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCallAdapterFactory.kt
+++ b/core/network/src/main/java/com/ibrahimkurt/core/network/calladapter/NetworkResultCallAdapterFactory.kt
@@ -1,5 +1,6 @@
 package com.ibrahimkurt.core.network.calladapter
 
+import com.ibrahimkurt.core.common.network.NetworkResult
 import retrofit2.Call
 import retrofit2.CallAdapter
 import retrofit2.Retrofit


### PR DESCRIPTION
- Changed the package declaration of NetworkResult.kt from `com.ibrahimkurt.core.network.calladapter` to `com.ibrahimkurt.core.common.network`.
- Added the import of the common `R` resource class in NetworkResult.kt and removed the previous core network `R` resource import.
- Added a new error string "error_unknown" in strings.xml which says "Bilinmeyen bir hata oluştu, bir süre sonra tekrar deneyiniz." (English: "An unknown error occurred, please try again later.").
- Imported `NetworkResult` from the new common network package in NetworkResultCall.kt, NetworkResultCallAdapter.kt, and NetworkResultCallAdapterFactory.kt to ensure consistency across network handling classes.