### PR TITLE
Increase encapsulation of detail data module classes

### DIFF
--- a/features/detail/data/src/main/kotlin/com/features/detail/data/di/DetailBindsModule.kt
+++ b/features/detail/data/src/main/kotlin/com/features/detail/data/di/DetailBindsModule.kt
@@ -10,7 +10,7 @@ import dagger.hilt.android.scopes.ViewModelScoped
 
 @Module
 @InstallIn(ViewModelComponent::class)
-abstract class DetailBindsModule {
+internal abstract class DetailBindsModule {
 
     @Binds
     @ViewModelScoped

--- a/features/detail/data/src/main/kotlin/com/features/detail/data/repository/DetailRepositoryImpl.kt
+++ b/features/detail/data/src/main/kotlin/com/features/detail/data/repository/DetailRepositoryImpl.kt
@@ -9,7 +9,7 @@ import com.ibrahimkurt.core.common.util.map
 import com.ibrahimkurt.core.network.calladapter.toResource
 import javax.inject.Inject
 
-class DetailRepositoryImpl @Inject constructor(
+internal class DetailRepositoryImpl @Inject constructor(
     private val detailDataSource: DetailApiService
 ) : DetailRepository {
 


### PR DESCRIPTION
- Changed visibility of `DetailBindsModule` and `DetailRepositoryImpl` to `internal` to restrict access within the module, enhancing encapsulation and limiting exposure of implementation details.